### PR TITLE
fix(fe26): verify if product.platform.title is not null before using …

### DIFF
--- a/components/ProductManagement/Products/index.tsx
+++ b/components/ProductManagement/Products/index.tsx
@@ -183,7 +183,7 @@ const Products = ({
               id={product._id || product.title}
               productImage={product.url}
               title={product.title}
-              category={product.platform.title}
+              category={product?.platform?.title}
               price={product.price.$numberDecimal}
               remove={() => removeRow(product._id ?? '')}
             />


### PR DESCRIPTION
Make optional the product.platform.title since in case of not having assigned a category, it will return the value as null or empty